### PR TITLE
feat(unsplash):! add unsplash support

### DIFF
--- a/backend/generate_with_rag.py
+++ b/backend/generate_with_rag.py
@@ -17,7 +17,7 @@ def get_language_instruction(language):
         "Italiano": "Rispondi in italiano con una grammatica corretta e uno stile naturale."
     }.get(language, "Responde en español con corrección y claridad.")
 
-def generate_text_with_context(topic, platform, tone, company, language, model, audience=None):
+def generate_text_with_context(topic, platform, tone, company, language, model,img_model, audience=None):
     """
     Genera contenido adaptado al contexto si la empresa es RuizTech.
     También incorpora información sobre la audiencia objetivo.

--- a/backend/image_generator.py
+++ b/backend/image_generator.py
@@ -16,13 +16,14 @@ headers = {
     "Accept": "image/*", 
 }
 
-def generate_image_url(text):
+def generate_image_url(text,model):
     """
     Genera una imagen usando el texto generado por el LLM.
     """
     try:
         print("Calling generate_post_image def...")
-        return generate_post_image(text[:2000], "stability", None)       
+        return generate_post_image(text[:2000], model, None)       
     except Exception as e:
         print("Error retrieving image from model:", e)
         return None 
+    

--- a/backend/img_gen/.env.example
+++ b/backend/img_gen/.env.example
@@ -3,6 +3,9 @@ STABILITY_API_KEY=""
 STABILITY_ENGINE="stable-diffusion-xl-1024-v1-0" # Alternative esrgan-v1-x2plus
 STABILITY_HOST="https://api.stability.ai"
 
+#UNSPLAS
+UNSPLASH_ACCESS_KEY=""
+
 #IMGE DEFAULT VALUES
 IMG_SUBJECT= 4 male programmers, 1 female programmer, working together in a modern office space, with computers and coffee cups around them
 IMG_STYLE=Modern and sleek

--- a/backend/img_gen/main.py
+++ b/backend/img_gen/main.py
@@ -6,6 +6,7 @@ from .models import ImagePrompt
 from .utils import detect_and_translate
 from .diffusers import main as diffusers_prompt
 from .stability import main as stability_prompt
+from .unsplash import main as unsplash_prompt
 
 pipe = None
 output_dir = "server/img-gen/output"
@@ -34,13 +35,21 @@ def generate_post_image(prompt, model, output_path: str = output_path):
     if model == "local":
             print("Generating image using local model...") # Debugging statement
             return diffusers_prompt(prompt, output_path) # Generate image using local model
-    elif model == "stability":
+    elif model == "remote":
+        try:
+            print("Generating image using remote models...")    # Debugging statement
             print("Generating image using Stability AI model...") # Debugging statement
-            resultado = stability_prompt(prompt, output_path) # Generate image using Stability AI model API
-            print(resultado)
-            return resultado
+            return stability_prompt(prompt, output_path) # Generate image using Stability AI model API
+        except Exception as e:
+            print(f"Error generating image using Stability AI model: {e}") # Debugging statement
+            try:
+                print("Generating image using Unsplash API...")
+                return unsplash_prompt(prompt, output_path)
+            except Exception as e:
+                print(f"Error generating image using Unsplash API: {e}") # Debugging statement
+            raise ValueError("Failed to generate image using both Stability AI and Unsplash APIs.")
     else:
-        raise ValueError(f"Invalid model: {model}. Choose 'local' or 'stability'.")
+        raise ValueError(f"Invalid model: {model}. Choose 'local' or 'remote'.")
 
 
 if __name__ == "__main__":

--- a/backend/img_gen/requirements.txt
+++ b/backend/img_gen/requirements.txt
@@ -10,3 +10,6 @@ safetensors
 # Translation Requirements
 langdetect
 deep-translator
+
+# Unsplash Requirements
+keybert

--- a/backend/img_gen/stability.py
+++ b/backend/img_gen/stability.py
@@ -20,7 +20,7 @@ default_image_prompt = ImagePrompt(
 )
 
 API_KEY = os.getenv("STABILITY_API_KEY")  # Ensure you have set this in your .env file
-if not API_KEY:
+if not API_KEY and __name__ == "__main__":
     raise ValueError("API_KEY not found. Please set STABILITY_API_KEY in your .env file.")
 ENGINE_ID = os.getenv("STABILITY_ENGINE")  
 API_HOST = os.getenv("STABILITY_HOST")

--- a/backend/img_gen/unsplash.py
+++ b/backend/img_gen/unsplash.py
@@ -1,0 +1,69 @@
+import requests
+import os
+import argparse
+from dotenv import load_dotenv
+from .models import ImagePrompt
+from .utils import extract_keywords, download_image_from_url, get_image_base64_from_url
+
+load_dotenv()
+UNSPLASH_ACCESS_KEY = os.getenv("UNSPLASH_ACCESS_KEY")
+if (not UNSPLASH_ACCESS_KEY or UNSPLASH_ACCESS_KEY == "") and __name__ == "__main__":
+    raise ValueError("UNSPLASH_ACCESS_KEY environment variable is not set.")
+
+default_image_prompt = ImagePrompt(
+    subject=os.getenv("IMG_SUBJECT"),
+    style=os.getenv("IMG_STYLE"),
+    medium=os.getenv("IMG_MEDIUM"),
+    lighting=os.getenv("IMG_LIGHTING"),
+    color_palette=os.getenv("IMG_COLOR_PALETTE"),
+    composition=os.getenv("IMG_COMPOSITION"),
+    resolution=os.getenv("IMG_RESOLUTION"),
+    contrast=os.getenv("IMG_CONTRAST"),
+    mood=os.getenv("IMG_MOOD"),
+    details=os.getenv("IMG_DETAILS"),
+)
+output_path = "server/image-gen/output/output.png"
+
+def search_unsplash_by_keywords(keywords):
+    try:
+        query = ",".join(keywords[:3])  # combinar palabras clave
+        url = f"https://api.unsplash.com/search/photos?query={query}&per_page=1"
+        headers = {"Authorization": f"Client-ID {UNSPLASH_ACCESS_KEY}"}
+        
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            results = response.json()
+            if results["results"]:
+                return results["results"][0]["urls"]["regular"]
+            else:
+                print("No images found for the given keywords.")
+                return None
+        else:
+            raise Exception(f"Unsplash API error {response.status_code}: {response.text}")
+    except Exception as e:
+        print(f"Error searching Unsplash: {e}")
+        return None
+
+def main(img = default_image_prompt, output_path = "server/image-gen/output/output.png"):
+    unsplash_img  = search_unsplash_by_keywords(extract_keywords(img.to_prompt() if isinstance(img, ImagePrompt) else img, top_n=5))
+    return download_image_from_url(unsplash_img, output_path) if output_path != "" and output_path is not None else get_image_base64_from_url(unsplash_img)
+
+if __name__ == "__main__":
+    # Argument parser for command line arguments
+    parser = argparse.ArgumentParser(description="Generate images using Stable Diffusion.")
+    parser.add_argument(
+        "--path",
+        type=str,
+        default=output_path,
+        help="Path to save the generated image (default: output/output.png)",
+    )
+    parser.add_argument(
+        "--img_prompt",
+        type=str,
+        default=None,
+        help="User ImagePrompt as a string for image generation (default: environment-based default_image_prompt)",
+    )
+    args = parser.parse_args()
+
+
+    main(img=args.img_prompt if args.img_prompt else default_image_prompt, output_path=args.path)

--- a/backend/img_gen/utils.py
+++ b/backend/img_gen/utils.py
@@ -4,6 +4,8 @@ import io
 import base64
 from langdetect import detect
 from deep_translator import GoogleTranslator
+from keybert import KeyBERT
+import requests
 
 def Image2Base64(image: Image.Image) -> str:
     """
@@ -71,6 +73,7 @@ def save_image(image, filepath):
 
 
 def detect_and_translate(text: str) -> str:
+    text = text.replace("#", "").strip()  # Remove hashtags and extra spaces
     detected_lang = detect(text)
     print(f"🌍 Detected language: {detected_lang}")
     if detected_lang != "en":
@@ -78,3 +81,24 @@ def detect_and_translate(text: str) -> str:
         print(f"🌐 Translated text: {translated}")
         return translated
     return text
+
+
+def extract_keywords(text, top_n=5):
+    kw_model = KeyBERT()
+    keywords = kw_model.extract_keywords(text, top_n=top_n, stop_words='english')
+    print(f"🔑 Extracted keywords: {keywords}")
+    return [kw for kw, score in keywords]
+
+def download_image_from_url(url, output_path="output/output.jpg"):
+    img_data = requests.get(url).content
+    # with open(filename, "wb") as handler:
+    #     handler.write(img_data)
+    save_image(Image.open(io.BytesIO(img_data)), output_path)
+
+def get_image_base64_from_url(url):
+    response = requests.get(url)
+    if response.status_code == 200:
+        base64_image = base64.b64encode(response.content).decode('utf-8')
+        return f"data:image/png;base64,{base64_image}"
+    else:
+        raise Exception(f"Error al descargar imagen: {response.status_code}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,6 +25,7 @@ class ContentRequest(BaseModel):
     tone: str
     language: str
     audience: Optional[str] = None
+    img_model: Optional[str] = "stability"
     model: str
     generate_image: bool = True
 
@@ -42,13 +43,14 @@ def generate_content(data: ContentRequest):
         tone=data.tone,
         language=data.language,
         model=data.model,
+        img_model=data.img_model,
         audience=data.audience
     )
 
     image_url = None
     if data.generate_image:
         # Solo pasamos el texto generado
-        image_url = generate_image_url(text)
+        image_url = generate_image_url(text, data.img_model)
 
     return {
         "text": text,


### PR DESCRIPTION
# Unsplash Support
Now using unsplash API as back-up for image generation.

- backend now calls img_gen using `local` | `remote`options as in **data.img_model**


- recursive 'stability'>'unsplash' workflow when *error* | *no API Key* | *lack of credit*