### PR TITLE
feat(pexels): add pexels img-gen support

### DIFF
--- a/backend/img_gen/main.py
+++ b/backend/img_gen/main.py
@@ -3,13 +3,14 @@ import os
 from dotenv import load_dotenv
 load_dotenv()
 from .models import ImagePrompt
-from .utils import detect_and_translate, is_ollama_installed
+from .utils import detect_and_translate, translate_image_prompt, is_ollama_installed, is_ollama_running
 from .diffusers import main as diffusers_prompt
 from .stability import main as stability_prompt
 from .unsplash import main as unsplash_prompt
+from .pexels import main as pexels_prompt
 
 pipe = None
-output_dir = "server/img-gen/output"
+output_dir = "backend/img_gen/output"
 output_filename = "output.png"
 output_path = os.path.join(output_dir, output_filename)
 
@@ -30,30 +31,60 @@ def generate_post_image(prompt, model, output_path: str = output_path):
     if not isinstance(prompt, ImagePrompt):
         prompt = detect_and_translate(prompt)
     elif isinstance(prompt, ImagePrompt):
-         for key, value in prompt.__dict__.items():
-            value = detect_and_translate(value) if value != "" and value is not None else ""
-    if model == "local":
+         prompt = translate_image_prompt(prompt).to_prompt()
+    print(f"Prompt: {prompt}") # Debugging statement
+    print(f"Model: {model}") # Debugging statement
+    model_environment, model_name = model.split(":")
+    if model_environment == "local":
             print("Generating image using local model...") # Debugging statement
             if not is_ollama_installed():
-                raise EnvironmentError("Ollama is not installed. Please install Ollama to use the local model.")
+                raise OSError("Ollama is not installed. Please install Ollama to use the local model.")
+            elif not is_ollama_running():
+                raise OSError("Ollama is not running. Please start Ollama to use the local model.")
             else:
                 return diffusers_prompt(prompt, output_path)
- # Generate image using local model
-    elif model == "remote":
-        try:
-            print("Generating image using remote models...")    # Debugging statement
-            print("Generating image using Stability AI model...") # Debugging statement
-            return stability_prompt(prompt, output_path) # Generate image using Stability AI model API
-        except Exception as e:
-            print(f"Error generating image using Stability AI model: {e}") # Debugging statement
+    elif model_environment == "remote":
+        if model_name == "all":
+            try:
+                print("Generating image using remote models...")    # Debugging statement
+                print("Generating image using Stability AI model...") # Debugging statement
+                return stability_prompt(prompt, output_path) # Generate image using Stability AI model API
+            except Exception as e:
+                print(f"Error generating image using Stability AI model: {e}") # Debugging statement
+                try:
+                    print("Generating image using Pexels API...")
+                    return pexels_prompt(prompt, output_path)
+                except Exception as e:
+                    print(f"Error generating image using Pexels API: {e}") # Debugging statement
+                    try:
+                        print("Generating image using Unsplash API...")
+                        return unsplash_prompt(prompt, output_path)
+                    except Exception as e:
+                        print(f"Error generating image using Unsplash API: {e}") # Debugging statement
+                        raise ValueError("Failed to generate image using both Stability AI, Pexels and Unsplash APIs.")
+        elif model_name == "unsplash":
             try:
                 print("Generating image using Unsplash API...")
                 return unsplash_prompt(prompt, output_path)
             except Exception as e:
                 print(f"Error generating image using Unsplash API: {e}") # Debugging statement
-            raise ValueError("Failed to generate image using both Stability AI and Unsplash APIs.")
+                raise ValueError("Failed to generate image using Unsplash API.")
+        elif model_name == "pexels":
+            try:
+                print("Generating image using Pexels API...")
+                return pexels_prompt(prompt, output_path)
+            except Exception as e:
+                print(f"Error generating image using Pexels API: {e}")
+                raise ValueError("Failed to generate image using Pexels API.")
+        elif model_name == "stability":
+            try:
+                print("Generating image using Stability AI model...")
+                return stability_prompt(prompt, output_path) # Generate image using Stability AI model API
+            except Exception as e:
+                print(f"Error generating image using Stability AI model: {e}")
+                raise ValueError("Failed to generate image using Stability AI model.")  
     else:
-        raise ValueError(f"Invalid model: {model}. Choose 'local' or 'remote'.")
+        raise ValueError(f"Invalid model: {model}. Supported models are 'local:local', 'remote:all', 'remote:unsplash', 'remote:pexels', and 'remote:stability'.")
 
 
 if __name__ == "__main__":
@@ -62,7 +93,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--path",
         type=str,
-        default="",
+        default=output_path,
         help="Path to save the generated image (default: output/output.png)",
     )
     parser.add_argument(
@@ -74,20 +105,21 @@ if __name__ == "__main__":
     parser.add_argument(
         "--model",
         type=str,
-        choices=["local", "stability"],
-        default="stability",
+        choices=["local:local", "remote:all", "remote:unsplash", "remote:pexels", "remote:stability"],
+        default="remote:all",
         help="Model to use for image generation (default: local)",
     )
     args = parser.parse_args()
 
-    # Detect language and translate if necessary
-    try:
-         prompt = detect_and_translate(args.img_prompt)  
-    except Exception as e:
-        print(f"Error detecting or translating prompt: {e}")
+    if not args.img_prompt or args.img_prompt == "":
+        # If no prompt is provided, use the default image prompt
+        prompt = detect_and_translate(default_image_prompt.to_prompt)
+    else:
+        prompt = args.img_prompt
+
 
     # Generate image using the specified model
     try:
-        generate_post_image(prompt = prompt, model = args.model, output_path = args.path)
+        generate_post_image(prompt = args.img_prompt, model = args.model, output_path = args.path)
     except Exception as e:
         print(f"Error generating image: {e}")

--- a/backend/img_gen/pexels.py
+++ b/backend/img_gen/pexels.py
@@ -1,0 +1,77 @@
+import requests
+import os
+import argparse
+from dotenv import load_dotenv
+from .models import ImagePrompt
+from .utils import extract_keywords, download_image_from_url, get_image_base64_from_url
+
+load_dotenv()
+PEXELS_API_KEY = os.getenv("PEXELS_API_KEY")
+if (not PEXELS_API_KEY or PEXELS_API_KEY == "") and __name__ == "__main__":
+    raise ValueError("PEXELS_API_KEY environment variable is not set.")
+
+default_image_prompt = ImagePrompt(
+    subject=os.getenv("IMG_SUBJECT"),
+    style=os.getenv("IMG_STYLE"),
+    medium=os.getenv("IMG_MEDIUM"),
+    lighting=os.getenv("IMG_LIGHTING"),
+    color_palette=os.getenv("IMG_COLOR_PALETTE"),
+    composition=os.getenv("IMG_COMPOSITION"),
+    resolution=os.getenv("IMG_RESOLUTION"),
+    contrast=os.getenv("IMG_CONTRAST"),
+    mood=os.getenv("IMG_MOOD"),
+    details=os.getenv("IMG_DETAILS"),
+)
+
+output_path = "server/image-gen/output/output.png"
+
+def search_pexels_by_keywords(keywords):
+    try:
+        query = " ".join(keywords[:3])  # combinar palabras clave
+        url = f"https://api.pexels.com/v1/search?query={query}&per_page=1"
+        headers = {"Authorization": PEXELS_API_KEY}
+
+        response = requests.get(url, headers=headers)
+        if response.status_code == 200:
+            results = response.json()
+            if results["photos"]:
+                return results["photos"][0]["src"]["large"]
+            else:
+                print("No images found for the given keywords.")
+                return None
+        else:
+            raise Exception(f"Pexels API error {response.status_code}: {response.text}")
+    except Exception as e:
+        print(f"Error searching Pexels: {e}")
+        return None
+
+def main(img=default_image_prompt, output_path="server/image-gen/output/output.png"):
+    image_url = search_pexels_by_keywords(
+        extract_keywords(img.to_prompt() if isinstance(img, ImagePrompt) else img, top_n=5)
+    )
+    return (
+        download_image_from_url(image_url, output_path)
+        if output_path
+        else get_image_base64_from_url(image_url)
+    )
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate images using Pexels API.")
+    parser.add_argument(
+        "--path",
+        type=str,
+        default=output_path,
+        help="Path to save the generated image (default: output/output.png)",
+    )
+    parser.add_argument(
+        "--img_prompt",
+        type=str,
+        default=None,
+        help="ImagePrompt as a string for image generation (default: env-based prompt)",
+    )
+    args = parser.parse_args()
+
+    main(
+        img=args.img_prompt if args.img_prompt else default_image_prompt,
+        output_path=args.path
+    )

--- a/backend/img_gen/utils.py
+++ b/backend/img_gen/utils.py
@@ -4,10 +4,33 @@ import io
 import base64
 from langdetect import detect
 from deep_translator import GoogleTranslator
+from .models import ImagePrompt
 from keybert import KeyBERT
 import requests
 import subprocess
 
+
+# OLLAMA FUNCTIONS
+
+def is_ollama_installed():
+    try:
+        result = subprocess.run(["ollama", "--version"], capture_output=True, text=True, check=True)
+        print(f"Ollama installed. Version: {result.stdout.strip()}")
+        return True
+    except FileNotFoundError:
+        print("❌ Ollama is not installed. Please install it from https://ollama.com/docs/installation.")
+        return False
+    except subprocess.CalledProcessError as e:
+        print(f"⚠️ Error trying to run Ollama: {e}")
+        return False
+def is_ollama_running(host="http://localhost:11434") -> bool:
+    try:
+        response = requests.get(f"{host}/api/tags", timeout=2)
+        return True
+    except requests.exceptions.RequestException:
+        print("❌ Ollama is not running. Please start it from https://ollama.com/docs/installation.")
+        return False
+    
 # STRING FUNCTIONS
 
 def detect_and_translate(text: str) -> str:
@@ -20,6 +43,14 @@ def detect_and_translate(text: str) -> str:
         return translated
     return text
 
+def translate_image_prompt(prompt: ImagePrompt) -> ImagePrompt:
+    translated_fields = {}
+    for key, value in prompt.__dict__.items():
+        if isinstance(value, str) and value.strip() != "":
+            translated_fields[key] = detect_and_translate(value)
+        else:
+            translated_fields[key] = value
+    return ImagePrompt(**translated_fields)
 
 def extract_keywords(text, top_n=5):
     kw_model = KeyBERT()
@@ -107,18 +138,6 @@ def get_image_base64_from_url(url):
     else:
         raise Exception(f"Error al descargar imagen: {response.status_code}")
 
-# OLLAMA FUNCTIONS
 
-def is_ollama_installed():
-    try:
-        result = subprocess.run(["ollama", "--version"], capture_output=True, text=True, check=True)
-        print(f"Ollama installed. Version: {result.stdout.strip()}")
-        return True
-    except FileNotFoundError:
-        print("❌ Ollama is not installed. Please install it from https://ollama.com/docs/installation.")
-        return False
-    except subprocess.CalledProcessError as e:
-        print(f"⚠️ Error trying to run Ollama: {e}")
-        return False
 
 


### PR DESCRIPTION
# Pexels Support PR
- add **Pexels** support.
- bug fix: check if **Ollama** is running.
- Changes in `model`parameter.
- *All model* recursion workflow.

## Pexel Support
- Now using Pexels API as image generation alternative.
- API Key will be needed.

## Model Parameter Selection
`model`parameter will contain now two arguments separated with a semicolon: `environment:model`:

- `local:local` for local generation with diffusers
- `remote:all` for a recursive try **Stability**>>**Pexels**>>**Unsplash**. First successfull API call will generate the image
- `remote:stability` for *Stability*
- `remote:pexels` for *Pexels*
- `remote:unsplash` for *Unsplash*

## Ollama check
When local model is called, it will be checked if Ollama is installed in the system, as well if there's any instance of Ollama server running.